### PR TITLE
Add mypy notebooks check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
       - name: Run mypy
         run: |
-          jupyter nbconvert --to script docs/examples/*.ipynb
+          pixi run jupyter nbconvert --to script docs/examples/*.ipynb
           for file in docs/examples/*.txt; do mv -- "$file" "${file%.txt}.py"; done
-          mypy docs/examples/*.py
+          pixi run mypy docs/examples/*.py
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
       - name: Run mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ jobs:
       - name: pre-commit
         run: pixi run pre-commit-run --color=always --show-diff-on-failure
 
+  mypy-example-nbs:
+    name: Check notebooks mypy
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+      - name: Run mypy
+        run: |
+          jupyter nbconvert --to script docs/examples/*.ipynb
+          for file in docs/examples/*.txt; do mv -- "$file" "${file%.txt}.py"; done
+          mypy docs/examples/*.py
+
   unit-tests:
     name: Unit Tests
     timeout-minutes: 30


### PR DESCRIPTION
When moving the documentation to read the docs this check got lost. It's important to have it because the Optuna example is not ran every time the docs are build and this provides at least static type checking.
# Checklist

- [ ] Added a `CHANGELOG.rst` entry
