### PR TITLE
Delete traces from migration to pixi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           pixi run -e ${{ matrix.env }} postinstall
           pixi run -e ${{ matrix.env }} coverage
       - name: Upload coverage reports to Codecov
-        if: matrix.env == 'py312'
+        if: matrix.env == 'py312' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3.1.3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,10 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           environments: ${{ matrix.env }}
-      - name: Install repository
+      - name: Install repository and generate code coverage report
         run: |
           pixi run -e ${{ matrix.env }} postinstall
           pixi run -e ${{ matrix.env }} coverage
-      - name: Generate code coverage report
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v3.1.3
-        with:
-          file: ./coverage.xml
       - name: Upload coverage reports to Codecov
         if: matrix.env == 'py312'
         uses: codecov/codecov-action@v3.1.3


### PR DESCRIPTION
Some traces of the CI before migrating to pixi were left. This PR removes them as `matrix.python-version` is not defined. It also uploads only one report to codecov.
# Checklist

- [ ] Added a `CHANGELOG.rst` entry
