### PR TITLE
Fix trigger of PyPI action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,9 @@
 name: Package
-on: [push]
+on:
+  push:
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The PyPI publishing is only triggered if the event is a published release, see
https://github.com/Quantco/metalearners/blob/main/.github/workflows/package.yml#L29

Yet, as of now, only pushes (on branches or tags) trigger the action.

Hence, this change includes the publishing of a release as a trigger for the action.

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
