### PR TITLE
PyPI action: Specify OIDC permissions and GitHub environment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,10 @@ jobs:
     name: Upload to PyPI
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: pypi
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Previous failure:

https://github.com/Quantco/metalearners/actions/runs/9842817281

- [ ] Added a `CHANGELOG.rst` entry
