### PR TITLE
Add errors in outcome validation and tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,7 @@ Changelog
 
 * Raise a custom error if only one class is present in a classification outcome.
 
-* Raise a custom error if the outcome classes present in all the treatment variants are
-  not the same so the reason is more understandable.
+* Raise a custom error if there are some treatment variants which have seen classification outcomes which have not appeared for some other treatment variant.
 
 0.6.0 (2024-07-08)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changelog
 
 * Changed the index columns order in ``MetaLearnerGridSearch.results_``.
 
-* Raise a custom error if only one class is present in the outcome so the reason is more understandable.
+* Raise a custom error if only one class is present in a classification outcome.
 
 * Raise a custom error if the outcome classes present in all the treatment variants are
   not the same so the reason is more understandable.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Changelog
 
 * Changed the index columns order in ``MetaLearnerGridSearch.results_``.
 
+* Raise a custom error if only one class is present in the outcome so the reason is more understandable.
+
+* Raise a custom error if the outcome classes present in all the treatment variants are
+  not the same so the reason is more understandable.
+
 0.6.0 (2024-07-08)
 ------------------
 

--- a/metalearners/drlearner.py
+++ b/metalearners/drlearner.py
@@ -93,7 +93,7 @@ class DRLearner(_ConditionalAverageOutcomeMetaLearner):
         n_jobs_base_learners: int | None = None,
     ) -> Self:
         self._validate_treatment(w)
-        self._validate_outcome(y)
+        self._validate_outcome(y, w)
 
         self._treatment_variants_indices = []
 

--- a/metalearners/metalearner.py
+++ b/metalearners/metalearner.py
@@ -336,7 +336,7 @@ class MetaLearner(ABC):
                     )
             if len(classes_0) == 1:
                 raise ValueError(
-                    "There is only one class present in the outcome. Please check your data."
+                    f"There is only one class present in the classification outcome: {classes_0}. Please check your data."
                 )
 
     def _validate_models(self) -> None:

--- a/metalearners/metalearner.py
+++ b/metalearners/metalearner.py
@@ -332,7 +332,7 @@ class MetaLearner(ABC):
             for tv in range(self.n_variants):
                 if set(np.unique(y[w == tv])) != classes_0:
                     raise ValueError(
-                        "Not all variants have the same classes. Please check your data."
+                        f"Variants 0 and {tv} have seen different sets of classification outcomes. Please check your data."
                     )
             if len(classes_0) == 1:
                 raise ValueError(

--- a/metalearners/metalearner.py
+++ b/metalearners/metalearner.py
@@ -317,7 +317,7 @@ class MetaLearner(ABC):
                 f"Yet we found the values {set(np.unique(w))}."
             )
 
-    def _validate_outcome(self, y: Vector) -> None:
+    def _validate_outcome(self, y: Vector, w: Vector) -> None:
         if (
             self.is_classification
             and not self._supports_multi_class()
@@ -327,6 +327,17 @@ class MetaLearner(ABC):
                 f"{self.__class__.__name__} does not support multiclass classification."
                 f" Yet we found {len(np.unique(y))} classes."
             )
+        if self.is_classification:
+            classes_0 = set(np.unique(y[w == 0]))
+            for tv in range(self.n_variants):
+                if set(np.unique(y[w == tv])) != classes_0:
+                    raise ValueError(
+                        "Not all variants have the same classes. Please check your data."
+                    )
+            if len(classes_0) == 1:
+                raise ValueError(
+                    "There is only one class present in the outcome. Please check your data."
+                )
 
     def _validate_models(self) -> None:
         """Validate that the base models are appropriate.

--- a/metalearners/rlearner.py
+++ b/metalearners/rlearner.py
@@ -169,7 +169,7 @@ class RLearner(MetaLearner):
     ) -> Self:
 
         self._validate_treatment(w)
-        self._validate_outcome(y)
+        self._validate_outcome(y, w)
 
         self._variants_indices = []
 

--- a/metalearners/slearner.py
+++ b/metalearners/slearner.py
@@ -152,7 +152,7 @@ class SLearner(MetaLearner):
         n_jobs_base_learners: int | None = None,
     ) -> Self:
         self._validate_treatment(w)
-        self._validate_outcome(y)
+        self._validate_outcome(y, w)
         self._fitted_treatments = convert_treatment(w)
 
         mock_model = self.nuisance_model_factory[_BASE_MODEL](

--- a/metalearners/tlearner.py
+++ b/metalearners/tlearner.py
@@ -59,7 +59,7 @@ class TLearner(_ConditionalAverageOutcomeMetaLearner):
         n_jobs_base_learners: int | None = None,
     ) -> Self:
         self._validate_treatment(w)
-        self._validate_outcome(y)
+        self._validate_outcome(y, w)
 
         self._treatment_variants_indices = []
 

--- a/metalearners/xlearner.py
+++ b/metalearners/xlearner.py
@@ -85,7 +85,7 @@ class XLearner(_ConditionalAverageOutcomeMetaLearner):
         n_jobs_base_learners: int | None = None,
     ) -> Self:
         self._validate_treatment(w)
-        self._validate_outcome(y)
+        self._validate_outcome(y, w)
 
         self._treatment_variants_indices = []
 

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -706,8 +706,8 @@ def test_validate_treatment_error_different_instantiation(metalearner_prefix):
 )
 def test_validate_outcome_multi_class(metalearner_prefix, success):
     covariates = np.zeros((20, 1))
-    w = np.array([0, 1] * 10)
-    y = np.array([0, 1] * 8 + [2] * 4)
+    w = np.array([0] * 10 + [1] * 10)
+    y = np.array([0, 1, 2, 3, 4] * 4)
 
     factory = metalearner_factory(metalearner_prefix)
     learner = factory(

--- a/tests/test_metalearner.py
+++ b/tests/test_metalearner.py
@@ -1076,7 +1076,8 @@ def test_validate_outcome_one_class(implementation, use_pandas, rng):
         LogisticRegression,
     )
     with pytest.raises(
-        ValueError, match="There is only one class present in the outcome."
+        ValueError,
+        match="There is only one class present in the classification outcome",
     ):
         ml.fit(X, y, w)
 
@@ -1102,5 +1103,7 @@ def test_validate_outcome_different_classes(implementation, use_pandas, rng):
         LinearRegression,
         LogisticRegression,
     )
-    with pytest.raises(ValueError, match="Not all variants have the same classes."):
+    with pytest.raises(
+        ValueError, match="have seen different sets of classification outcomes."
+    ):
         ml.fit(X, y, w)

--- a/tests/test_metalearner.py
+++ b/tests/test_metalearner.py
@@ -1052,3 +1052,55 @@ def test_n_jobs_base_learners(implementation, rng):
 
     np.testing.assert_allclose(ml.predict(X, False), ml_2.predict(X, False))
     np.testing.assert_allclose(ml.predict(X, True), ml_2.predict(X, True))
+
+
+@pytest.mark.parametrize(
+    "implementation",
+    [TLearner, SLearner, XLearner, RLearner, DRLearner],
+)
+@pytest.mark.parametrize("use_pandas", [False, True])
+def test_validate_outcome_one_class(implementation, use_pandas, rng):
+    X = rng.standard_normal((10, 2))
+    y = np.zeros(10)
+    w = rng.integers(0, 2, 10)
+    if use_pandas:
+        X = pd.DataFrame(X)
+        y = pd.Series(y)
+        w = pd.Series(w)
+
+    ml = implementation(
+        True,
+        2,
+        LogisticRegression,
+        LinearRegression,
+        LogisticRegression,
+    )
+    with pytest.raises(
+        ValueError, match="There is only one class present in the outcome."
+    ):
+        ml.fit(X, y, w)
+
+
+@pytest.mark.parametrize(
+    "implementation",
+    [TLearner, SLearner, XLearner, RLearner, DRLearner],
+)
+@pytest.mark.parametrize("use_pandas", [False, True])
+def test_validate_outcome_different_classes(implementation, use_pandas, rng):
+    X = rng.standard_normal((4, 2))
+    y = np.array([0, 1, 0, 0])
+    w = np.array([0, 0, 1, 1])
+    if use_pandas:
+        X = pd.DataFrame(X)
+        y = pd.Series(y)
+        w = pd.Series(w)
+
+    ml = implementation(
+        True,
+        2,
+        LogisticRegression,
+        LinearRegression,
+        LogisticRegression,
+    )
+    with pytest.raises(ValueError, match="Not all variants have the same classes."):
+        ml.fit(X, y, w)


### PR DESCRIPTION
This PR:
* Solves #34 
* Adds test for the fact that the same classes are present in all the treatment variants, this is needed because if not the different outcome models would have different output shapes (if some class is not present in the training data the model does not predict it)
* Raises an error if there is only one class present. This is needed because there's no `sklearn` standard if this happens, for example `lightgbm` assumes there is another class and when calling `predict_proba` it has 2 columns, `LogisticRegression` raises an error, `DecisionTree` only predicts 1 column when calling `predict_proba`... As this would require different handling depending on the model I believe that the best option is to just raise an error.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
