### PR TITLE
Improve memory usage of `MetaLearnerGridSearch`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@
 Changelog
 =========
 
+0.8.0 (2024-07-xx)
+------------------
+
+**New features**
+
+* Add optional ``store_raw_results`` and ``store_results`` parameters to :class:`metalearners.grid_search.MetaLearnerGridSearch`.
+
+* Renamed :class:`metalearners.grid_search._GSResult` to :class:`metalearners.grid_search.GSResult`.
+
+
 0.7.0 (2024-07-12)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 
 * Renamed :class:`metalearners.grid_search._GSResult` to :class:`metalearners.grid_search.GSResult`.
 
+* Added ``grid_size_`` attribute to :class:`metalearners.grid_search.MetaLearnerGridSearch`.
+
 
 0.7.0 (2024-07-12)
 ------------------

--- a/docs/examples/example_gridsearch.ipynb
+++ b/docs/examples/example_gridsearch.ipynb
@@ -331,6 +331,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "What if I run out of memory?\n",
+    "----------------------------\n",
+    "\n",
+    "If you're conducting an optimization task over a large grid with a substantial dataset,\n",
+    "it is possible that memory usage issues may arise. To try to solve these, you can minimize\n",
+    "memory usage by adjusting your settings.\n",
+    "\n",
+    "In that case you can set ``store_raw_results=False``, the grid search will then operate\n",
+    "with a generator rather than a list, significantly reducing memory usage.\n",
+    "\n",
+    "If the ``results_ DataFrame`` is what you're after, you can simply set ``store_results=True``.\n",
+    "However, if you aim to iterate over the {class}`~metalearners.metalearner.MetaLearner` objects,\n",
+    "you can set ``store_results=False``. Consequently, ``raw_results_`` will become a generator\n",
+    "object yielding {class}`~metalearners.grid_search.GSResult`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Further comments\n",
     "-------------------\n",
     "* We strongly recommend only reusing base models if they have been trained on\n",

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -358,10 +358,7 @@ class MetaLearnerGridSearch:
         if self.store_results:
             self.results_ = _format_results(results=self.raw_results_)  # type: ignore
             if not self.store_raw_results:
-                # This just checks that the generator is empty
-                try:
-                    next(self.raw_results_)  # type: ignore
-                except StopIteration:
-                    self.raw_results_ = None
+                # The generator will be empty so we replace it with None
+                self.raw_results_ = None
         else:
             self.results_ = None

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -199,9 +199,9 @@ class MetaLearnerGridSearch:
       will be None. This configuration can be useful in the case the grid search is big
       and you do not want to store all MetaLearners objects rather evaluate them after
       fitting each one and just store one.
-    """
 
-    # TODO: Add a reference to a docs example once it is written.
+    For an illustration see :ref:`our example on Tuning hyperparameters of a MetaLearner with MetaLearnerGridSearch <example-grid-search>`.
+    """
 
     def __init__(
         self,

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -200,6 +200,8 @@ class MetaLearnerGridSearch:
       and you do not want to store all MetaLearners objects rather evaluate them after
       fitting each one and just store one.
 
+    ``grid_size_`` will contain the number of hyperparameter combinations after fitting.
+
     For an illustration see :ref:`our example on Tuning hyperparameters of a MetaLearner with MetaLearnerGridSearch <example-grid-search>`.
     """
 

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -352,9 +352,9 @@ class MetaLearnerGridSearch:
         parallel = Parallel(
             n_jobs=self.n_jobs, verbose=self.verbose, return_as=return_as
         )
-        self.raw_results = parallel(delayed(_fit_and_score)(job) for job in jobs)
+        self.raw_results_ = parallel(delayed(_fit_and_score)(job) for job in jobs)
         if self.store_results:
-            self.results_ = _format_results(results=self.raw_results)
+            self.results_ = _format_results(results=self.raw_results_)  # type: ignore
             if not self.store_raw_results:
                 # This just checks that the generator is empty
                 try:

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -201,6 +201,10 @@ class MetaLearnerGridSearch:
       fitting each one and just store one.
 
     ``grid_size_`` will contain the number of hyperparameter combinations after fitting.
+    This attribute may be useful in the case ``store_raw_results = False`` and ``store_results = False``.
+    In that case, the generator object returned in ``raw_results_`` doesn't trigger the fitting
+    of individual metalearners until explicitly requested, e.g. in a loop. This attribute
+    can be use to track the progress, for instance, by creating a progress bar or a similar utility.
 
     For an illustration see :ref:`our example on Tuning hyperparameters of a MetaLearner with MetaLearnerGridSearch <example-grid-search>`.
     """

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -348,7 +348,7 @@ class MetaLearnerGridSearch:
 
         self.grid_size_ = len(jobs)
         self.raw_results_: list[GSResult] | Generator[GSResult, None, None] | None
-        self.results_: pd.DataFrame | None
+        self.results_: pd.DataFrame | None = None
 
         return_as = "list" if self.store_raw_results else "generator_unordered"
         parallel = Parallel(
@@ -360,5 +360,3 @@ class MetaLearnerGridSearch:
             if not self.store_raw_results:
                 # The generator will be empty so we replace it with None
                 self.raw_results_ = None
-        else:
-            self.results_ = None

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -361,3 +361,5 @@ class MetaLearnerGridSearch:
                     next(self.raw_results_)  # type: ignore
                 except StopIteration:
                     self.raw_results_ = None
+        else:
+            self.results_ = None

--- a/metalearners/grid_search.py
+++ b/metalearners/grid_search.py
@@ -348,9 +348,7 @@ class MetaLearnerGridSearch:
                         metalerner_fit_params=kwargs,
                     )
                 )
-        return_as = (
-            "list" if self.store_raw_results else "generator"
-        )  # Can we use generator_unordered?
+        return_as = "list" if self.store_raw_results else "generator_unordered"
         parallel = Parallel(
             n_jobs=self.n_jobs, verbose=self.verbose, return_as=return_as
         )

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -156,6 +156,7 @@ def test_metalearnergridsearch_smoke(
     assert gs.results_ is not None
     assert gs.results_.shape[0] == expected_n_configs
     assert gs.results_.index.names == expected_index_cols
+    assert gs.grid_size_ == expected_n_configs
 
     train_scores_cols = set(
         c[6:] for c in list(gs.results_.columns) if c.startswith("train_")

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -301,3 +301,26 @@ def test_metalearnergridsearch_store(
     gs.fit(X, y, w, X_test, y_test, w_test)
     assert isinstance(gs.raw_results_, expected_type_raw_results)
     assert isinstance(gs.results_, expected_type_results)
+
+
+def test_metalearnergridsearch_error(grid_search_data):
+    X, _, y, w, X_test, _, y_test, w_test = grid_search_data
+    n_variants = len(np.unique(w))
+
+    metalearner_params = {
+        "is_classification": False,
+        "n_variants": n_variants,
+        "n_folds": 2,
+        "random_state": 1,
+    }
+
+    gs = MetaLearnerGridSearch(
+        metalearner_factory=SLearner,
+        metalearner_params=metalearner_params,
+        base_learner_grid={"base_model": [LinearRegression, LGBMRegressor]},
+        param_grid={"base_model": {"LGBMRegressor": {"n_estimators": [1, 2]}}},
+    )
+    with pytest.raises(
+        ValueError, match="should not be specified in metalearner_params"
+    ):
+        gs.fit(X, y, w, X_test, y_test, w_test)

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from types import GeneratorType
+
 import numpy as np
+import pandas as pd
 import pytest
 from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
@@ -259,3 +262,42 @@ def test_metalearnergridsearch_reuse_propensity_smoke(grid_search_data):
     assert gs.results_ is not None
     assert gs.results_.shape[0] == 2
     assert len(gs.results_.index.names) == 5
+
+
+@pytest.mark.parametrize(
+    "store_raw_results, store_results, expected_type_raw_results, expected_type_results",
+    [
+        (True, True, list, pd.DataFrame),
+        (True, False, list, type(None)),
+        (False, True, type(None), pd.DataFrame),
+        (False, False, GeneratorType, type(None)),
+    ],
+)
+def test_metalearnergridsearch_store(
+    store_raw_results,
+    store_results,
+    expected_type_raw_results,
+    expected_type_results,
+    grid_search_data,
+):
+    X, _, y, w, X_test, _, y_test, w_test = grid_search_data
+    n_variants = len(np.unique(w))
+
+    metalearner_params = {
+        "is_classification": False,
+        "n_variants": n_variants,
+        "n_folds": 2,
+    }
+
+    gs = MetaLearnerGridSearch(
+        metalearner_factory=SLearner,
+        metalearner_params=metalearner_params,
+        base_learner_grid={"base_model": [LinearRegression, LGBMRegressor]},
+        param_grid={"base_model": {"LGBMRegressor": {"n_estimators": [1, 2]}}},
+        store_raw_results=store_raw_results,
+        store_results=store_results,
+    )
+
+    gs.fit(X, y, w, X_test, y_test, w_test)
+    assert isinstance(gs.raw_results_, expected_type_raw_results)
+    assert isinstance(gs.results_, expected_type_results)


### PR DESCRIPTION
The idea of this PR is to improve the memory usage of `MetaLearnerGridSearch`. The main issue was that all metalearners instances were saved in memory. Each of this was referenced in two places, the `jobs` list and the `raw_results_` list. 
* To remove it from the `jobs` list now `_FitAndScoreJob` stores only the factory and the parameters, then the `MetaLearner` object is created inside the `joblib` job which runs `_fit_and_score`.
* For the reference in the `raw_results_` now one can choose to return a generator from `joblib.parallel` instead of materializing all the results in a list.

It is important to notice that if the user wants to iterate themselves over the results and not materialize them (for example, to compute policy values and only store the one with the highest policy) then `store_results`  and `store_raw_results` must be set to `False` as if `store_results` is `True` then the generator would be consumed when calling `_format_results`.

 It also adds a `grid_size_` attribute which can be useful if a generator is returned.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
