### PR TITLE
Split `fit` in `fit_all_nuisance` and `fit_all_treatment`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@
 Changelog
 =========
 
+0.8.0 (2024-07-xx)
+------------------
+
+**New features**
+
+* Added :meth:`metalearners.metalearner.MetaLearner.fit_all_nuisance` and
+  :meth:`metalearners.metalearner.MetaLearner.fit_all_treatment`.
+
+
 0.7.0 (2024-07-12)
 ------------------
 

--- a/metalearners/metalearner.py
+++ b/metalearners/metalearner.py
@@ -744,6 +744,41 @@ class MetaLearner(ABC):
             ] = result.cross_fit_estimator
 
     @abstractmethod
+    def fit_all_nuisance(
+        self,
+        X: Matrix,
+        y: Vector,
+        w: Vector,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+    ) -> Self:
+        """Fit all nuisance models of the MetaLearner.
+
+        If pre-fitted models were passed at instantiation, these are never refitted.
+
+        For the parameters check :meth:`metalearners.metalearner.MetaLearner.fit`.
+        """
+        ...
+
+    @abstractmethod
+    def fit_all_treatment(
+        self,
+        X: Matrix,
+        y: Vector,
+        w: Vector,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+    ) -> Self:
+        """Fit all treatment models of the MetaLearner.
+
+        For the parameters check :meth:`metalearners.metalearner.MetaLearner.fit`.
+        """
+        ...
+
     def fit(
         self,
         X: Matrix,
@@ -791,7 +826,27 @@ class MetaLearner(ABC):
         the same data splits where possible. Note that if there are several models to be synchronized which are
         classifiers, these cannot be split via stratification.
         """
-        ...
+        self.fit_all_nuisance(
+            X=X,
+            y=y,
+            w=w,
+            n_jobs_cross_fitting=n_jobs_cross_fitting,
+            fit_params=fit_params,
+            synchronize_cross_fitting=synchronize_cross_fitting,
+            n_jobs_base_learners=n_jobs_base_learners,
+        )
+
+        self.fit_all_treatment(
+            X=X,
+            y=y,
+            w=w,
+            n_jobs_cross_fitting=n_jobs_cross_fitting,
+            fit_params=fit_params,
+            synchronize_cross_fitting=synchronize_cross_fitting,
+            n_jobs_base_learners=n_jobs_base_learners,
+        )
+
+        return self
 
     def predict_nuisance(
         self,

--- a/metalearners/rlearner.py
+++ b/metalearners/rlearner.py
@@ -156,7 +156,7 @@ class RLearner(MetaLearner):
     def _supports_multi_class(cls) -> bool:
         return False
 
-    def fit(
+    def fit_all_nuisance(
         self,
         X: Matrix,
         y: Vector,
@@ -165,13 +165,9 @@ class RLearner(MetaLearner):
         fit_params: dict | None = None,
         synchronize_cross_fitting: bool = True,
         n_jobs_base_learners: int | None = None,
-        epsilon: float = _EPSILON,
     ) -> Self:
-
         self._validate_treatment(w)
         self._validate_outcome(y, w)
-
-        self._variants_indices = []
 
         qualified_fit_params = self._qualified_fit_params(fit_params)
         self._validate_fit_params(qualified_fit_params)
@@ -214,7 +210,22 @@ class RLearner(MetaLearner):
         )
         self._assign_joblib_nuisance_results(results)
 
+        return self
+
+    def fit_all_treatment(
+        self,
+        X: Matrix,
+        y: Vector,
+        w: Vector,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+        epsilon: float = _EPSILON,
+    ) -> Self:
+        qualified_fit_params = self._qualified_fit_params(fit_params)
         treatment_jobs: list[_ParallelJoblibSpecification] = []
+        self._variants_indices = []
         for treatment_variant in range(1, self.n_variants):
 
             is_treatment = w == treatment_variant
@@ -246,6 +257,7 @@ class RLearner(MetaLearner):
                     n_jobs_cross_fitting=n_jobs_cross_fitting,
                 )
             )
+        parallel = Parallel(n_jobs=n_jobs_base_learners)
         results = parallel(
             delayed(_fit_cross_fit_estimator_joblib)(job) for job in treatment_jobs
         )

--- a/metalearners/slearner.py
+++ b/metalearners/slearner.py
@@ -141,7 +141,7 @@ class SLearner(MetaLearner):
             random_state=random_state,
         )
 
-    def fit(
+    def fit_all_nuisance(
         self,
         X: Matrix,
         y: Vector,
@@ -173,6 +173,18 @@ class SLearner(MetaLearner):
             n_jobs_cross_fitting=n_jobs_cross_fitting,
             fit_params=qualified_fit_params[NUISANCE][_BASE_MODEL],
         )
+        return self
+
+    def fit_all_treatment(
+        self,
+        X: Matrix,
+        y: Vector,
+        w: Vector,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+    ) -> Self:
         return self
 
     def predict(

--- a/metalearners/tlearner.py
+++ b/metalearners/tlearner.py
@@ -48,7 +48,7 @@ class TLearner(_ConditionalAverageOutcomeMetaLearner):
     def _supports_multi_class(cls) -> bool:
         return True
 
-    def fit(
+    def fit_all_nuisance(
         self,
         X: Matrix,
         y: Vector,
@@ -90,6 +90,18 @@ class TLearner(_ConditionalAverageOutcomeMetaLearner):
             if job is not None
         )
         self._assign_joblib_nuisance_results(results)
+        return self
+
+    def fit_all_treatment(
+        self,
+        X: Matrix,
+        y: Vector,
+        w: Vector,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+    ) -> Self:
         return self
 
     def predict(

--- a/tests/test_metalearner.py
+++ b/tests/test_metalearner.py
@@ -68,7 +68,7 @@ class _TestMetaLearner(MetaLearner):
 
     def _validate_models(self) -> None: ...
 
-    def fit(
+    def fit_all_nuisance(
         self,
         X,
         y,
@@ -83,6 +83,18 @@ class _TestMetaLearner(MetaLearner):
                 self.nuisance_model_specifications()[model_kind]["cardinality"](self)
             ):
                 self.fit_nuisance(X, y, model_kind, model_ord)
+        return self
+
+    def fit_all_treatment(
+        self,
+        X,
+        y,
+        w,
+        n_jobs_cross_fitting: int | None = None,
+        fit_params: dict | None = None,
+        synchronize_cross_fitting: bool = True,
+        n_jobs_base_learners: int | None = None,
+    ):
         for model_kind in self.__class__.treatment_model_specifications():
             for model_ord in range(
                 self.treatment_model_specifications()[model_kind]["cardinality"](self)


### PR DESCRIPTION
This PR splits the `fit` method of each MetaLearner into `fit_all_nuisance` and `fit_all_treatment`. The goal is to make it easier for the user to "intervene" while fitting between the two steps.
# Checklist

- [x] Added a `CHANGELOG.rst` entry
