### PR TITLE
Increase time limit grid search example

### DIFF
--- a/docs/examples/example_gridsearch.ipynb
+++ b/docs/examples/example_gridsearch.ipynb
@@ -362,6 +362,9 @@
  "metadata": {
   "language_info": {
    "name": "python"
+  },
+  "mystnb": {
+   "execution_timeout": 60
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In some commits readthedocs failed, see [here](https://github.com/Quantco/metalearners/pull/66/commits/db9c46c7ee6a468739c4f23c87968531cd3b7496) or [here](https://github.com/Quantco/metalearners/pull/64/commits/38efcea1783a84183183dbf57dbf5044064802f0). In both cases pushing an empty commit to trigger rebuilding the docs solved it. We can't check the reason why it failed because it's dumped on a file but as it is not a consistent failure my hypothesis is that it is due to reaching the maximum execution time. This PR increases the timeout for the grid search example which is the one that failed.

PD: I opened an [issue](https://github.com/executablebooks/MyST-NB/issues/616) to be able to show the traceback in case the execution of a notebook fails. If that is fixed we could set `nb_execution_show_tb = True` in `conf.py` and we would see the error on the output of ReadtheDocs.
# Checklist

- [ ] Added a `CHANGELOG.rst` entry
