### PR TITLE
Adapt import of `check_X_y` to comply with `scikit-learn` 1.6

### DIFF
--- a/metalearners/_utils.py
+++ b/metalearners/_utils.py
@@ -10,11 +10,12 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import scipy
-from sklearn.base import check_array, check_X_y, is_classifier, is_regressor
+from sklearn.base import is_classifier, is_regressor
 from sklearn.ensemble import (
     HistGradientBoostingClassifier,
     HistGradientBoostingRegressor,
 )
+from sklearn.utils import check_array, check_X_y
 
 from metalearners._typing import Matrix, PredictMethod, Vector, _ScikitModel
 
@@ -131,6 +132,7 @@ def check_propensity_score(
         )
 
     if features is not None:
+
         check_X_y(features, propensity_scores, multi_output=True, **check_kwargs)
     else:
         check_array(propensity_scores, **check_kwargs)


### PR DESCRIPTION
We used to import `check_X_y` and `check_array` from `sklearn.base`. Since [PR 29696](https://github.com/scikit-learn/scikit-learn/pull/29696/files#diff-ac9c452d8c660d2516089c8448596912c22417c7c690f079715593e61ef6ee0d) -- released in version 1.6.0 -- these function are no longer available in `sklearn.base`, but rather only in `sklearn.utils`.

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
